### PR TITLE
Added 'Record-Count' header to API responses

### DIFF
--- a/routes/catalogue_nsd.rb
+++ b/routes/catalogue_nsd.rb
@@ -661,6 +661,8 @@ class CatalogueV2 < SonataCatalogue
     else
       # Do the query
       nss = Nsd.where(keyed_params)
+      # Set total count for results
+      headers 'Record-Count' => nss.count.to_s
       logger.info "Catalogue: NSDs=#{nss}"
       if nss && nss.size.to_i > 0
         logger.info "Catalogue: leaving GET /api/v2/network-services?#{query_string} with #{nss}"

--- a/routes/catalogue_pd.rb
+++ b/routes/catalogue_pd.rb
@@ -682,6 +682,8 @@ class CatalogueV2 < SonataCatalogue
     else
       # Do the query
       pks = Pkgd.where(keyed_params)
+      # Set total count for results
+      headers 'Record-Count' => pks.count.to_s
       logger.info "Catalogue: PDs=#{pks}"
       if pks && pks.size.to_i > 0
         logger.info "Catalogue: leaving GET /api/v2/packages?#{query_string} with #{pks}"

--- a/routes/catalogue_sonp.rb
+++ b/routes/catalogue_sonp.rb
@@ -251,6 +251,8 @@ class CatalogueV2 < SonataCatalogue
 
     # Do the query
     file_list = FileContainer.where(keyed_params)
+    # Set total count for results
+    headers 'Record-Count' => file_list.count.to_s
     logger.info "Catalogue: leaving GET /api/v2/son-packages?#{query_string} with #{file_list}"
 
     # Paginate results

--- a/routes/catalogue_vnfd.rb
+++ b/routes/catalogue_vnfd.rb
@@ -633,6 +633,8 @@ class CatalogueV2 < SonataCatalogue
     else
       # Do the query
       vnfs = Vnfd.where(keyed_params)
+      # Set total count for results
+      headers 'Record-Count' => vnfs.count.to_s
       logger.info "Catalogue: VNFDs=#{vnfs}"
       if vnfs && vnfs.size.to_i > 0
         logger.info "Catalogue: leaving GET /api/v2/vnfs?#{query_string} with #{vnfs}"


### PR DESCRIPTION
A new field 'Record-Count' has been added to the response of queries in the next APIs:
- /network-services?
- /vnfs?
- /packages?
- /son-packages?